### PR TITLE
Fix quiz scoring with correct key

### DIFF
--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -13,9 +13,14 @@ add_action('wp_ajax_vq_submit_quiz','vq_submit_quiz');
 add_action('wp_ajax_nopriv_vq_submit_quiz','vq_submit_quiz');
 function vq_submit_quiz(){
   check_ajax_referer('vq_nonce','nonce');
-  $vid=intval($_POST['video_id']); $answers=$_POST['answers']; $quiz=get_post_meta($vid,'vq_quiz',true);
+  $vid=intval($_POST['video_id']);
+  $answers=isset($_POST['answers'])?(array)$_POST['answers']:array();
+  $quiz=get_post_meta($vid,'vq_quiz',true);
+  if(!is_array($quiz)) $quiz=array();
   $score=0; $total=count($quiz);
-  foreach($quiz as $qi=>$q){ if(isset($answers[$qi]) && $answers[$qi]==$q['answer']) $score++; }
+  foreach($quiz as $qi=>$q){
+    if(isset($answers[$qi]) && intval($answers[$qi])===intval($q['correct'])) $score++;
+  }
   $passed=$score==$total; wp_send_json_success(['score'=>$score,'total'=>$total,'passed'=>$passed]);
 }
 // Survey rate


### PR DESCRIPTION
## Summary
- ensure quiz submissions compare against the stored `correct` answer key
- handle empty quiz submissions robustly

## Testing
- `php -l includes/ajax.php`


------
https://chatgpt.com/codex/tasks/task_b_68a855506d108328aa68283026c1d9fc