### PR TITLE
feat: add video gallery layout

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,6 +1,6 @@
 jQuery(function($){
   function updateProgress(card, percent){ card.find('.vq-progress-bar').css('width', percent+'%'); }
-  $(".vq-player").on("ended",function(){
+  $(document).on("ended",".vq-player",function(){
     var card=$(this).closest('.vq-step-card');
     updateProgress(card,33);
     $(this).siblings(".vq-start-quiz").show();
@@ -10,11 +10,11 @@ jQuery(function($){
       }
     });
   });
-  $(".vq-start-quiz").on("click",function(){
+  $(document).on("click",".vq-start-quiz",function(){
     $("#"+$(this).data("target")).slideDown(); $(this).hide();
     updateProgress($(this).closest('.vq-step-card'),66);
   });
-  $(".vq-quiz-submit").on("click",function(){
+  $(document).on("click",".vq-quiz-submit",function(){
     var btn=$(this),vid=btn.data("video"),answers={};
     btn.closest(".vq-quiz-step").find(".vq-q").each(function(i,q){ answers[i]=$(q).find("input:checked").val(); });
     $.post(vqAjax.ajaxUrl,{action:"vq_submit_quiz",nonce:vqAjax.nonce,video_id:vid,answers:answers},function(res){
@@ -25,7 +25,7 @@ jQuery(function($){
       }
     });
   });
-  $(".vq-survey-rating .star").on("click",function(){
+  $(document).on("click",".vq-survey-rating .star",function(){
     var wrap=$(this).parent(),vid=wrap.data("video"),rate=$(this).data("value");
     wrap.find(".star").removeClass("active"); $(this).prevAll().addBack().addClass("active");
     $.post(vqAjax.ajaxUrl,{action:"vq_survey_rate",nonce:vqAjax.nonce,video_id:vid,rate:rate});
@@ -46,23 +46,9 @@ jQuery(function($){
 });
 
 
+function vqFmt(sec){sec=Math.floor(sec||0);var h=Math.floor(sec/3600),m=Math.floor((sec%3600)/60),s=sec%60;return (h>0?(h+":"+(m<10?"0":"")):"")+m+":"+(s<10?"0":"")+s;}
 /* === Prevent Seek & Show Duration (non-breaking) === */
 jQuery(function($){
-  function vqFmt(sec){sec=Math.floor(sec||0);var h=Math.floor(sec/3600),m=Math.floor((sec%3600)/60),s=sec%60;return (h>0?(h+":"+(m<10?"0":"")):"")+m+":"+(s<10?"0":"")+s;}
-  $(".vq-player.vq-no-seek").each(function(){
-    var v=this,$v=$(this),last=0,lock=false,id=$v.data("video-id");
-    v.addEventListener("loadedmetadata",function(){ $('.vq-duration[data-video-id="'+id+'"]').text(vqFmt(v.duration)); });
-    v.addEventListener("seeking",function(){ if(lock) return; lock=true; v.currentTime=last; lock=false; });
-    v.addEventListener("timeupdate",function(){ last=v.currentTime; });
-    $v.on("keydown",function(e){var k=e.key.toLowerCase(); if(['arrowleft','arrowright','home','end','j','l'].includes(k)){e.preventDefault();e.stopPropagation();}});
-    $v.on("mousedown touchstart",function(){ setTimeout(function(){ v.currentTime=last; },0); });
-  });
-});
-
-
-/* === Prevent Seek & Show Duration (non-breaking) === */
-jQuery(function($){
-  function vqFmt(sec){sec=Math.floor(sec||0);var h=Math.floor(sec/3600),m=Math.floor((sec%3600)/60),s=sec%60;return (h>0?(h+":"+(m<10?"0":"")):"")+m+":"+(s<10?"0":"")+s;}
   $(".vq-player.vq-no-seek").each(function(){
     var v=this,$v=$(this),last=0,lock=false,id=$v.data("video-id");
     v.addEventListener("loadedmetadata",function(){ $('.vq-duration[data-video-id="'+id+'"]').text(vqFmt(v.duration)); });
@@ -142,13 +128,33 @@ jQuery(function($){
 jQuery(function($){
   function unlockNext(card){
     var next=card.next('.vq-step-card');
-    if(!next.length) return;
-    next.find('.vq-locked').hide();
-    next.find('.vq-video-wrap').show();
-    $('html,body').animate({scrollTop: next.offset().top-60},400);
+    if(next.length){
+      next.find('.vq-locked').hide();
+      next.find('.vq-video-wrap').show();
+      $('html,body').animate({scrollTop: next.offset().top-60},400);
+    } else {
+      var current=$('.vq-gallery-item.active');
+      var nextItem=current.next('.vq-gallery-item');
+      if(nextItem.length){ nextItem.trigger('click'); }
+    }
   }
   $(document).on('click','.vq-next-video',function(e){
     e.preventDefault();
     unlockNext($(this).closest('.vq-step-card'));
+  });
+});
+
+/* === Gallery interaction === */
+jQuery(function($){
+  $(document).on('click','.vq-gallery-item',function(e){
+    e.preventDefault();
+    var item=$(this);
+    var vid=item.data('video-id');
+    var tpl=$('#vq-gallery-content-'+vid);
+    if(tpl.length){
+      $('#vq-gallery-main').html(tpl.html());
+    }
+    item.addClass('active').siblings().removeClass('active');
+    $('html,body').animate({scrollTop: $('#vq-gallery-main').offset().top-60},300);
   });
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -159,3 +159,90 @@ video.vq-no-seek::-webkit-media-controls-current-time-display,
 video.vq-no-seek::-webkit-media-controls-time-remaining-display {
   display: none !important;
 }
+
+/* === Gallery layout === */
+.vq-gallery {
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 20px;
+  align-items: flex-start;
+}
+.vq-gallery-player {
+  flex: 1;
+}
+.vq-gallery-player video {
+  width: 100%;
+  border-radius: var(--vq-radius);
+}
+.vq-gallery-player .vq-step-card {
+  margin: 0;
+}
+.vq-gallery-list {
+  width: 280px;
+  max-height: 600px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  background: var(--vq-bg);
+  border: 1px solid var(--vq-border);
+  border-radius: var(--vq-radius);
+}
+.vq-gallery-item {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 8px;
+  padding: 6px;
+  border: 1px solid var(--vq-border);
+  border-radius: var(--vq-radius);
+  transition: background .2s, box-shadow .2s, border-color .2s;
+}
+.vq-gallery-item:hover {
+  background: #f9fafb;
+  box-shadow: 0 1px 2px rgba(0,0,0,.05);
+}
+.vq-gallery-item.active {
+  background: #eff6ff;
+  border-color: var(--vq-primary);
+}
+.vq-gallery-item img {
+  width: 80px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+.vq-gallery-index {
+  width: 22px;
+  height: 22px;
+  background: var(--vq-primary);
+  color: #fff;
+  border-radius: 50%;
+  font-size: .75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.vq-gallery-item.active .vq-gallery-index {
+  background: var(--vq-primary-hover);
+}
+.vq-gallery-title {
+  font-size: .9rem;
+  flex: 1;
+}
+
+@media (max-width: 768px) {
+  .vq-gallery {
+    flex-direction: column;
+  }
+  .vq-gallery-list {
+    width: 100%;
+    max-height: none;
+    order: 2;
+  }
+  .vq-gallery-player {
+    order: 1;
+  }
+}

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -183,3 +183,144 @@ function vq_top_videos_shortcode($atts){
   return ob_get_clean();
 }
 add_shortcode('vq_top_videos','vq_top_videos_shortcode');
+
+/**
+ * نمایش گالری ویدیوها به صورت لیست و پخش در یک پلیر
+ * [vq_video_gallery category="all"]
+ */
+function vq_video_gallery_shortcode($atts){
+  $atts = shortcode_atts([
+    'category' => 'all',
+  ], $atts);
+
+  $args = [
+    'post_type'      => ['vq_video','videoquest'],
+    'posts_per_page' => -1,
+    'post_status'    => 'publish',
+    'orderby'        => 'ID',
+    'order'          => 'ASC',
+  ];
+
+  if ( !empty($atts['category']) && $atts['category'] !== 'all' ) {
+    $slug = sanitize_title($atts['category']);
+    $args['tax_query'] = [
+      'relation' => 'OR',
+      [
+        'taxonomy' => 'vq_category',
+        'field'    => 'slug',
+        'terms'    => $slug,
+      ],
+      [
+        'taxonomy' => 'category',
+        'field'    => 'slug',
+        'terms'    => $slug,
+      ],
+    ];
+  }
+
+  $q = new WP_Query($args);
+  if( ! $q->have_posts() ){
+    return '<div class="vq-empty">ویدیویی یافت نشد.</div>';
+  }
+
+  $video_ids = [];
+  while( $q->have_posts() ){ $q->the_post();
+    $video_ids[] = get_the_ID();
+  }
+  wp_reset_postdata();
+
+  if( empty($video_ids) ){
+    return '<div class="vq-empty">ویدیویی یافت نشد.</div>';
+  }
+
+  // Helper برای ساختن محتوای ویدیو با همه امکانات
+  $render_video = function($vid,$index){
+    $user_id = get_current_user_id();
+    $viewed  = get_user_meta($user_id, "vq_viewed_{$vid}", true);
+    $brand   = get_post_meta($vid,'vq_brand',true);
+    $points  = get_post_meta($vid,'vq_reward_points',true);
+    if($points==='') $points = 100;
+    $url     = get_post_meta($vid,'_vq_video_file',true);
+    $avg     = get_post_meta($vid,'vq_video_rating_avg',true);
+    $cnt     = get_post_meta($vid,'vq_video_rating_count',true);
+    if($avg==='') $avg = 0; if($cnt==='') $cnt = 0;
+    $quiz    = get_post_meta($vid,'vq_quiz',true);
+
+    ob_start();
+    echo '<div class="vq-step-card" data-step-index="'.esc_attr($index).'">';
+      echo '<div class="vq-progress"><div class="vq-progress-bar"></div></div>';
+      echo '<div class="vq-step-header"><h3>'.esc_html(get_the_title($vid)).'</h3>';
+      if($brand){ echo '<span class="vq-brand">'.esc_html($brand).'</span>'; }
+      echo '</div>';
+      echo '<div class="vq-step-body" style="display:block">';
+        echo '<div class="vq-video-wrap">';
+          echo '<video class="vq-player vq-no-seek" controls preload="metadata" controlsList="nodownload noplaybackrate noremoteplayback" disablePictureInPicture oncontextmenu="return false" data-video-id="'.esc_attr($vid).'">';
+            if($url){ echo '<source src="'.esc_url($url).'" type="video/mp4">'; }
+          echo '</video>';
+          echo '<div class="vq-video-meta">مدت: <span class="vq-duration" data-video-id="'.esc_attr($vid).'">--:--</span> · امتیاز: '.intval($points).'</div>';
+          echo '<button class="vq-next-step vq-start-quiz" style="display:none" data-target="quiz-'.esc_attr($vid).'">شروع آزمون</button>';
+        echo '</div>'; // .vq-video-wrap
+
+        if( is_array($quiz) && !empty($quiz) ){
+          echo '<div id="quiz-'.esc_attr($vid).'" class="vq-quiz-step" style="display:none">';
+          foreach($quiz as $qi=>$qrow){
+            $question = isset($qrow['question']) ? $qrow['question'] : '';
+            $options  = isset($qrow['options']) && is_array($qrow['options']) ? $qrow['options'] : [];
+            echo '<div class="vq-q"><p><b>'.esc_html($question).'</b></p>';
+            foreach($options as $oi=>$opt){
+              echo '<label><input type="radio" name="quiz_'.esc_attr($vid).'_'.esc_attr($qi).'" value="'.esc_attr($oi).'"> '.esc_html($opt).'</label><br>';
+            }
+            echo '</div>';
+          }
+          echo '<button class="vq-quiz-submit" data-video="'.esc_attr($vid).'">ارسال آزمون</button>';
+          echo '<div class="vq-quiz-feedback" style="display:none"></div>';
+          echo '</div>';
+        }
+
+        echo '<div class="vq-survey-step" style="display:none" id="survey-'.esc_attr($vid).'">';
+          echo '<p>کیفیت آزمون را ارزیابی کنید:</p>';
+          echo '<div class="vq-video-rate-wrap">';
+            echo '<div class="vq-video-rating" data-video="'.esc_attr($vid).'">';
+              for($i=1;$i<=5;$i++){ echo '<span class="star" data-value="'.esc_attr($i).'">★</span>'; }
+            echo '</div>';
+            echo '<div class="vq-rating-summary">میانگین: <b class="vq-avg">'.esc_html($avg).'</b> از 5 · <span class="vq-count">'.intval($cnt).'</span> رای</div>';
+          echo '</div>';
+          echo '<button class="vq-next-video" data-index="'.esc_attr($index).'">رفتن به ویدیو بعدی</button>';
+        echo '</div>';
+      echo '</div>'; // .vq-step-body
+    echo '</div>'; // .vq-step-card
+    return ob_get_clean();
+  };
+
+  ob_start();
+  echo '<div class="vq-gallery">';
+    // Player area
+    echo '<div class="vq-gallery-player" id="vq-gallery-main">';
+      echo $render_video($video_ids[0],0);
+    echo '</div>';
+
+    // List of videos
+    echo '<div class="vq-gallery-list">';
+    foreach($video_ids as $i=>$vid){
+      $thumb  = get_the_post_thumbnail_url($vid,'thumbnail');
+      $active = $i===0 ? ' active' : '';
+      echo '<div class="vq-gallery-item'.esc_attr($active).'" data-video-id="'.esc_attr($vid).'" data-index="'.esc_attr($i).'">';
+        echo '<span class="vq-gallery-index">'.intval($i+1).'</span>';
+        if($thumb){ echo '<img src="'.esc_url($thumb).'" alt="">'; }
+        echo '<span class="vq-gallery-title">'.esc_html(get_the_title($vid)).'</span>';
+      echo '</div>';
+    }
+    echo '</div>'; // .vq-gallery-list
+
+    // Hidden templates for other videos
+    foreach($video_ids as $i=>$vid){
+      if($i===0) continue;
+      echo '<div id="vq-gallery-content-'.esc_attr($vid).'" class="vq-gallery-template" style="display:none">';
+        echo $render_video($vid,$i);
+      echo '</div>';
+    }
+  echo '</div>';
+
+  return ob_get_clean();
+}
+add_shortcode('vq_video_gallery','vq_video_gallery_shortcode');


### PR DESCRIPTION
## Summary
- build `[vq_video_gallery]` that loads each video card (player, quiz, rating) while listing videos alongside
- update JS to swap gallery videos dynamically and keep plugin features intact
- tweak gallery styling for seamless integration
- polish gallery list with numbered badges, hover effects, and responsive layout
- auto-scroll player into view when switching videos

## Testing
- `php -l shortcodes.php`
- `php -l videoquest.php`


------
https://chatgpt.com/codex/tasks/task_b_68aee2618b7083288468fd2f84fc14d3