### PR TITLE
Add playlist layout option for video list

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,4 +1,42 @@
 jQuery(function($){
+  const $pl = $("#vq-playlist");
+  const $v  = $("#vq-main-player");
+  const $t  = $("#vq-now-title");
+
+  if($pl.length && $v.length){
+    $pl.on("click", ".vq-item", function(){
+      const $it   = $(this);
+      const src   = $it.data("src");
+      const vid   = $it.data("vid");
+      const title = $it.data("title")||'';
+
+      // 1) سوییچ سورس و شناسه ویدئو
+      if(src){
+        const wasPaused = $v[0].paused;
+        $v.find("source").attr("src", src);
+        $v.attr("data-video-id", vid);
+        $v[0].load();
+        if (!wasPaused) { $v[0].play().catch(()=>{}); } else { $v[0].play().catch(()=>{}); }
+      }
+
+      // 2) عنوان
+      if($t.length) $t.text(title);
+
+      // 3) اکتیو کردن آیتم
+      $pl.find(".vq-item.is-active").removeClass("is-active");
+      $it.addClass("is-active");
+
+      // 4) نمایش پنل مرتبط (کوییز/نظرسنجی) و مخفی کردن بقیه
+      $("#vq-panels .vq-panel").hide();
+      $('#vq-panels .vq-panel[data-panel="'+vid+'"]').show();
+
+      // 5) اسکرول اگر موبایل بود (اختیاری)
+      // $('html,body').animate({scrollTop: $('.vq-player-wrap').offset().top - 60}, 300);
+    });
+  }
+});
+
+jQuery(function($){
   function updateProgress(card, percent){ card.find('.vq-progress-bar').css('width', percent+'%'); }
   $(".vq-player").on("ended",function(){
     var card=$(this).closest('.vq-step-card');

--- a/assets/style.css
+++ b/assets/style.css
@@ -159,3 +159,29 @@ video.vq-no-seek::-webkit-media-controls-current-time-display,
 video.vq-no-seek::-webkit-media-controls-time-remaining-display {
   display: none !important;
 }
+
+/* === Playlist Layout === */
+.vq-grid{
+  display:grid; grid-template-columns: 2fr 1fr; gap:16px; align-items:start;
+}
+.vq-player-wrap{}
+.vq-aspect{ position:relative; aspect-ratio:16/9; background:#000; border-radius: var(--vq-radius); overflow:hidden; }
+.vq-aspect video{ position:absolute; inset:0; width:100%; height:100%; }
+
+.vq-playlist{ display:flex; flex-direction:column; gap:8px; max-height: calc(100vh - 220px); overflow:auto; }
+.vq-item{
+  display:grid; grid-template-columns: 120px 1fr; gap:10px;
+  border:1px solid var(--vq-border); border-radius: var(--vq-radius);
+  background:#fff; padding:8px; cursor:pointer; text-align:left;
+}
+.vq-item img{ width:100%; height:68px; object-fit:cover; border-radius:6px; }
+.vq-item-title{ display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; font-size:.95rem; }
+.vq-item.is-active{ outline:2px solid var(--vq-primary); background:#f0f7ff; }
+.vq-item-sub{ font-size:.8rem; color: var(--vq-muted); }
+.vq-sep{ padding:0 6px; color:#cbd5e1; }
+
+@media (max-width: 900px){
+  .vq-grid{ grid-template-columns:1fr; }
+  .vq-playlist{ flex-direction:row; overflow:auto; }
+  .vq-item{ grid-template-columns: 120px 1fr; min-width: 300px; }
+}


### PR DESCRIPTION
## Summary
- expand `[vq_video_list]` shortcode with new `layout` attribute supporting `accordion` and `playlist` modes
- implement playlist HTML structure and player/quiz panels
- add JS handler for switching videos within playlist and display corresponding panels
- style new playlist layout with responsive CSS

## Testing
- `php -l shortcodes.php`
- `node --check assets/script.js`


------
https://chatgpt.com/codex/tasks/task_b_68af00f321b08328b268f149e282d067