### PR TITLE
refactor: add quiz/survey rendering helpers

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -2,6 +2,20 @@
 if ( ! defined('ABSPATH') ) exit;
 
 /**
+ * رندر محتوای آزمون برای یک ویدئو
+ */
+function vq_render_quiz_panel($video_id){
+  echo '<div class="vq-quiz-step">'.__('اینجا سوالات آزمون ویدئو '.$video_id,'vq').'</div>';
+}
+
+/**
+ * رندر محتوای نظرسنجی برای یک ویدئو
+ */
+function vq_render_survey_panel($video_id){
+  echo '<div class="vq-survey-step">'.__('اینجا نظرسنجی ویدئو '.$video_id,'vq').'</div>';
+}
+
+/**
  * لیست ویدیوها به صورت آکاردئون
  * [vq_video_list category="all"]
  */
@@ -88,10 +102,9 @@ function vq_video_list_shortcode($atts){
           <?php foreach($videos as $v): ?>
             <div class="vq-panel" data-panel="<?php echo esc_attr($v['vid']); ?>" style="<?php echo $v['vid']===$first['vid']?'':'display:none'; ?>">
               <?php
-                // می‌تونی تکه‌های موجودت برای quiz/survey همان کارتی رو اینجا بخونی/بسازی
-                // نمونه خیلی کوتاه (درصورت داشتن متادیتا):
-                echo '<div class="vq-quiz-step">'.__('اینجا سوالات آزمون ویدئو '.$v['vid'],'vq').'</div>';
-                echo '<div class="vq-survey-step">'.__('اینجا نظرسنجی ویدئو '.$v['vid'],'vq').'</div>';
+                // رندر فرم‌های کوییز و نظرسنجی مربوط به هر ویدئو
+                vq_render_quiz_panel($v['vid']);
+                vq_render_survey_panel($v['vid']);
               ?>
             </div>
           <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- extract quiz and survey placeholder rendering into dedicated helper functions
- simplify playlist panel by calling new helpers instead of inline examples

## Testing
- `php -l shortcodes.php`
- `php -r 'define("ABSPATH", true); function __($s,$d=null){return $s;} function add_shortcode($tag,$func){} include "shortcodes.php"; ob_start(); vq_render_quiz_panel(1); vq_render_survey_panel(2); echo ob_get_clean();'`


------
https://chatgpt.com/codex/tasks/task_b_68af065a62f88328925ce178744b592a