### PR TITLE
Use total ratings instead of averages

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -54,10 +54,10 @@ function vq_video_list_shortcode($atts){
       $url   = get_post_meta($vid, '_vq_video_file', true);     // MP4
       $title = get_the_title();
       $thumb = get_the_post_thumbnail_url($vid,'medium') ?: ''; // اگر داری
-      $avg   = get_post_meta($vid,'vq_video_rating_avg',true);
+      $sum   = get_post_meta($vid,'vq_video_rating_sum',true);
       $cnt   = get_post_meta($vid,'vq_video_rating_count',true);
-      if ($avg === '' ) $avg = 0; if ($cnt === '' ) $cnt = 0;
-      $videos[] = compact('vid','url','title','thumb','avg','cnt');
+      if ($sum === '' ) $sum = 0; if ($cnt === '' ) $cnt = 0;
+      $videos[] = compact('vid','url','title','thumb','sum','cnt');
     }
     wp_reset_postdata();
 
@@ -80,7 +80,7 @@ function vq_video_list_shortcode($atts){
         <div class="vq-video-meta">
           مدت: <span class="vq-duration" data-video-id="<?php echo esc_attr($first['vid']); ?>">—</span>
           <span class="vq-sep">•</span>
-          امتیاز: <b class="vq-avg"><?php echo esc_html($first['avg']); ?></b> از 5 (<?php echo intval($first['cnt']); ?> رأی)
+          امتیاز: <b class="vq-sum"><?php echo esc_html($first['sum']); ?></b> (<?php echo intval($first['cnt']); ?> رأی)
         </div>
 
         <!-- اینجا همه فرم‌های کوییز/نظرسنجی را برای هر ویدئو رندر می‌کنیم اما مخفی؛ فقط اکتیو نمایش داده می‌شود -->
@@ -111,7 +111,7 @@ function vq_video_list_shortcode($atts){
               <span class="vq-item-sub">
                 <span class="vq-duration" data-video-id="<?php echo esc_attr($v['vid']); ?>">—</span>
                 <span class="vq-sep">•</span>
-                <span><?php echo esc_html($v['avg']); ?>/5</span>
+                <span class="vq-sum"><?php echo esc_html($v['sum']); ?></span>
               </span>
             </div>
           </button>
@@ -141,9 +141,9 @@ function vq_video_list_shortcode($atts){
     $url = get_post_meta($video_id, '_vq_video_file', true);
 
     // امتیاز فعلی برای نمایش اولیه
-    $avg = get_post_meta($video_id, 'vq_video_rating_avg', true);
+    $sum = get_post_meta($video_id, 'vq_video_rating_sum', true);
     $cnt = get_post_meta($video_id, 'vq_video_rating_count', true);
-    if ($avg === '' ) $avg = 0;
+    if ($sum === '' ) $sum = 0;
     if ($cnt === '' ) $cnt = 0;
 
     echo '<div class="vq-step-card" data-step-index="'.esc_attr($index).'">';
@@ -203,8 +203,8 @@ function vq_video_list_shortcode($atts){
             }
           echo '</div>';
 
-          // ✅ نمایش میانگین و تعداد رأی (JS آن را زنده آپدیت می‌کند)
-          echo '<div class="vq-rating-summary">میانگین: <b class="vq-avg">'.esc_html($avg).'</b> از 5 · <span class="vq-count">'.intval($cnt).'</span> رای</div>';
+          // ✅ نمایش مجموع و تعداد رأی (JS آن را زنده آپدیت می‌کند)
+          echo '<div class="vq-rating-summary">مجموع: <b class="vq-sum">'.esc_html($sum).'</b> · <span class="vq-count">'.intval($cnt).'</span> رای</div>';
         echo '</div>'; // .vq-video-rate-wrap
 
         echo '<button class="vq-next-video" data-index="'.esc_attr($index).'">رفتن به ویدیو بعدی</button>';
@@ -227,7 +227,7 @@ function vq_video_list_shortcode($atts){
 add_shortcode('vq_video_list','vq_video_list_shortcode');
 
 /**
- * بهترین ویدیوها بر اساس میانگین امتیاز
+ * بهترین ویدیوها بر اساس مجموع امتیاز
  * [vq_top_videos count="10"]
  */
 function vq_top_videos_shortcode($atts){
@@ -237,7 +237,7 @@ function vq_top_videos_shortcode($atts){
     'post_type'      => ['vq_video','videoquest'],
     'post_status'    => 'publish',
     'posts_per_page' => intval($atts['count']),
-    'meta_key'       => 'vq_video_rating_avg',
+    'meta_key'       => 'vq_video_rating_sum',
     'orderby'        => 'meta_value_num',
     'order'          => 'DESC',
   ]);
@@ -247,11 +247,11 @@ function vq_top_videos_shortcode($atts){
   if( $q->have_posts() ){
     while( $q->have_posts() ){ $q->the_post();
       $vid = get_the_ID();
-      $avg = get_post_meta($vid,'vq_video_rating_avg',true);
+      $sum = get_post_meta($vid,'vq_video_rating_sum',true);
       $cnt = get_post_meta($vid,'vq_video_rating_count',true);
-      if ($avg === '' ) $avg = 0;
+      if ($sum === '' ) $sum = 0;
       if ($cnt === '' ) $cnt = 0;
-      echo '<div class="vq-top-item"><span class="vq-top-title">'.esc_html(get_the_title()).'</span> <span class="vq-top-meta">— میانگین: '.esc_html($avg).' از 5 · '.intval($cnt).' رای</span></div>';
+      echo '<div class="vq-top-item"><span class="vq-top-title">'.esc_html(get_the_title()).'</span> <span class="vq-top-meta">— مجموع: <span class="vq-sum">'.esc_html($sum).'</span> امتیاز · '.intval($cnt).' رای</span></div>';
     }
     wp_reset_postdata();
   } else {


### PR DESCRIPTION
## Summary
- replace average rating usage with total rating sum
- show rating totals and vote counts in playlist, accordion, and top videos

## Testing
- `php -l shortcodes.php`
- `php -l includes/ajax.php`


------
https://chatgpt.com/codex/tasks/task_b_68af066240248328b95fb33544ab2ba7