### PR TITLE
feat: enhance quiz scoring and rating UI

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -57,7 +57,9 @@ jQuery(function($){
     btn.closest(".vq-quiz-step").find(".vq-q").each(function(i,q){ answers[i]=$(q).find("input:checked").val(); });
     $.post(vqAjax.ajaxUrl,{action:"vq_submit_quiz",nonce:vqAjax.nonce,video_id:vid,answers:answers},function(res){
       if(res.success){
-        btn.siblings(".vq-quiz-feedback").show().html(res.data.passed?"✅ ("+res.data.score+"/"+res.data.total+")":"❌ "+res.data.score+"/"+res.data.total);
+        var fb=btn.siblings(".vq-quiz-feedback").show();
+        fb.toggleClass('success',res.data.passed).toggleClass('fail',!res.data.passed)
+          .html(res.data.passed?"✅ ("+res.data.score+"/"+res.data.total+")":"❌ "+res.data.score+"/"+res.data.total);
         btn.hide(); btn.closest(".vq-quiz-step").siblings(".vq-survey-step").slideDown();
         updateProgress(btn.closest('.vq-step-card'),100);
       }
@@ -209,7 +211,7 @@ jQuery(document).on('click', '.vq-survey-rating .star, .vq-video-rating .star', 
       box.find('.vq-avg').text(res.data.avg);
       box.find('.vq-count').text(res.data.count);
       var item = jQuery('#vq-playlist .vq-item[data-vid="'+vid+'"]');
-      if(item.length && item.find('.vq-sum').length){ item.find('.vq-sum').text(res.data.avg); }
+      if(item.length && item.find('.vq-avg').length){ item.find('.vq-avg').text(res.data.avg); }
     }
   });
 });
@@ -243,7 +245,7 @@ jQuery(document).off('click.vqplstars')
       box.find('.vq-avg').text(res.data.avg);
       box.find('.vq-count').text(res.data.count);
       var item = jQuery('#vq-playlist .vq-item[data-vid="'+vid+'"]');
-      if(item.length && item.find('.vq-sum').length){ item.find('.vq-sum').text(res.data.avg); }
+      if(item.length && item.find('.vq-avg').length){ item.find('.vq-avg').text(res.data.avg); }
     }
   });
 });

--- a/assets/script_patched.js
+++ b/assets/script_patched.js
@@ -15,7 +15,9 @@ jQuery(function($){
     btn.closest(".vq-quiz-step").find(".vq-q").each(function(i,q){ answers[i]=$(q).find("input:checked").val(); });
     $.post(vqAjax.ajaxUrl,{action:"vq_submit_quiz",nonce:vqAjax.nonce,video_id:vid,answers:answers},function(res){
       if(res.success){
-        btn.siblings(".vq-quiz-feedback").show().html(res.data.passed?"✅ ("+res.data.score+"/"+res.data.total+")":"❌ "+res.data.score+"/"+res.data.total);
+        var fb=btn.siblings(".vq-quiz-feedback").show();
+        fb.toggleClass('success',res.data.passed).toggleClass('fail',!res.data.passed)
+          .html(res.data.passed?"✅ ("+res.data.score+"/"+res.data.total+")":"❌ "+res.data.score+"/"+res.data.total);
         btn.hide(); btn.closest(".vq-quiz-step").siblings(".vq-survey-step").slideDown();
         updateProgress(btn.closest('.vq-step-card'),100);
       }
@@ -90,7 +92,7 @@ jQuery(function($){
     $s.siblings().removeClass('active'); $s.prevAll().addBack().addClass('active');
     $.post(vqAjax.ajaxUrl,{action:'vq_rate_video',nonce:vqAjax.nonce,video_id:vid,rate:val},function(res){
       if(res && res.success){
-        wrap.find('.vq-avg b').text(res.data.avg);
+        wrap.find('.vq-avg').text(res.data.avg);
         wrap.find('.vq-count').text(' ('+res.data.count+' رای)');
       }
     });
@@ -103,7 +105,7 @@ jQuery(function($){
     var wrap=$(this).closest('.vq-step-card');
     // آپدیت نشان میانگین در هدر کارت اگر وجود داشت
     setTimeout(function(){
-      var avgText = wrap.find('.vq-video-rate-wrap .vq-avg b').text();
+      var avgText = wrap.find('.vq-video-rate-wrap .vq-avg').text();
       if(avgText){ 
         if(wrap.find('.vq-avg-badge').length){ wrap.find('.vq-avg-badge').text(avgText+'★'); }
         else { wrap.find('.vq-step-header').append('<span class="vq-avg-badge">'+avgText+'★</span>'); }
@@ -120,7 +122,7 @@ jQuery(function($){
     $.post(vqAjax.ajaxUrl,{action:'vq_get_rating',nonce:vqAjax.nonce,video_id:vid},function(res){
       if(res && res.success){
         var wrap=$('.vq-video-rate-wrap').has('[data-video="'+vid+'"]');
-        wrap.find('.vq-avg b').text(res.data.avg);
+        wrap.find('.vq-avg').text(res.data.avg);
         wrap.find('.vq-count').text(' ('+res.data.count+' رای)');
         var card=wrap.closest('.vq-step-card');
         if(card.find('.vq-avg-badge').length){ card.find('.vq-avg-badge').text(res.data.avg+'★'); }

--- a/assets/style.css
+++ b/assets/style.css
@@ -101,6 +101,8 @@
   margin-top: 10px;
   font-weight: 600;
 }
+.vq-quiz-feedback.success{ color:#16a34a; }
+.vq-quiz-feedback.fail{ color:#dc2626; }
 
 .vq-survey-rating .star,
 .vq-video-rating .star {
@@ -173,10 +175,12 @@ video.vq-no-seek::-webkit-media-controls-time-remaining-display {
   display:grid; grid-template-columns: 120px 1fr; gap:10px;
   border:1px solid var(--vq-border); border-radius: var(--vq-radius);
   background:#fff; padding:8px; cursor:pointer; text-align:left;
+  transition:background .2s, box-shadow .2s;
 }
 .vq-item img{ width:100%; height:68px; object-fit:cover; border-radius:6px; }
 .vq-item-title{ display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; font-size:.95rem; }
-.vq-item.is-active{ outline:2px solid var(--vq-primary); background:#f0f7ff; }
+.vq-item:hover{ background:#f1f5f9; }
+.vq-item.is-active{ box-shadow:0 0 0 2px var(--vq-primary); background:#f0f7ff; }
 .vq-item-sub{ font-size:.8rem; color: var(--vq-muted); }
 .vq-sep{ padding:0 6px; color:#cbd5e1; }
 

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -35,15 +35,22 @@ add_action('wp_ajax_vq_submit_quiz','vq_submit_quiz');
 add_action('wp_ajax_nopriv_vq_submit_quiz','vq_submit_quiz');
 function vq_submit_quiz(){
   check_ajax_referer('vq_nonce','nonce');
-  $vid=intval($_POST['video_id']);
-  $answers=isset($_POST['answers'])?(array)$_POST['answers']:array();
-  $quiz=get_post_meta($vid,'vq_quiz',true);
-  if(!is_array($quiz)) $quiz=array();
-  $score=0; $total=count($quiz);
+  $vid     = intval($_POST['video_id']);
+  $uid     = get_current_user_id();
+  $answers = isset($_POST['answers']) ? (array) $_POST['answers'] : array();
+  $quiz    = get_post_meta($vid,'vq_quiz',true);
+  if(!is_array($quiz)) $quiz = array();
+  $score = 0; $total = count($quiz);
   foreach($quiz as $qi=>$q){
     if(isset($answers[$qi]) && intval($answers[$qi])===intval($q['correct'])) $score++;
   }
-  $passed=$score==$total; wp_send_json_success(['score'=>$score,'total'=>$total,'passed'=>$passed]);
+  $passed = ($total > 0) ? (($score / $total) >= 0.7) : false;
+  if($uid){
+    update_user_meta($uid,"vq_quiz_score_$vid", $score);
+    update_user_meta($uid,"vq_quiz_total_$vid", $total);
+    update_user_meta($uid,"vq_quiz_passed_$vid", $passed ? 1 : 0);
+  }
+  wp_send_json_success(['score'=>$score,'total'=>$total,'passed'=>$passed]);
 }
 // Survey rate
 add_action('wp_ajax_vq_survey_rate','vq_survey_rate');

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -68,10 +68,10 @@ function vq_video_list_shortcode($atts){
       $url   = get_post_meta($vid, '_vq_video_file', true);     // MP4
       $title = get_the_title();
       $thumb = get_the_post_thumbnail_url($vid,'medium') ?: ''; // اگر داری
-      $sum   = get_post_meta($vid,'vq_video_rating_sum',true);
+      $avg   = get_post_meta($vid,'vq_video_rating_avg',true);
       $cnt   = get_post_meta($vid,'vq_video_rating_count',true);
-      if ($sum === '' ) $sum = 0; if ($cnt === '' ) $cnt = 0;
-      $videos[] = compact('vid','url','title','thumb','sum','cnt');
+      if ($avg === '' ) $avg = 0; if ($cnt === '' ) $cnt = 0;
+      $videos[] = compact('vid','url','title','thumb','avg','cnt');
     }
     wp_reset_postdata();
 
@@ -94,7 +94,7 @@ function vq_video_list_shortcode($atts){
         <div class="vq-video-meta">
           مدت: <span class="vq-duration" data-video-id="<?php echo esc_attr($first['vid']); ?>">—</span>
           <span class="vq-sep">•</span>
-          امتیاز: <b class="vq-sum"><?php echo esc_html($first['sum']); ?></b> (<?php echo intval($first['cnt']); ?> رأی)
+          امتیاز: <b class="vq-avg"><?php echo esc_html($first['avg']); ?></b> (<?php echo intval($first['cnt']); ?> رأی)
         </div>
 
         <!-- اینجا همه فرم‌های کوییز/نظرسنجی را برای هر ویدئو رندر می‌کنیم اما مخفی؛ فقط اکتیو نمایش داده می‌شود -->
@@ -124,7 +124,7 @@ function vq_video_list_shortcode($atts){
               <span class="vq-item-sub">
                 <span class="vq-duration" data-video-id="<?php echo esc_attr($v['vid']); ?>">—</span>
                 <span class="vq-sep">•</span>
-                <span class="vq-sum"><?php echo esc_html($v['sum']); ?></span>
+                <span class="vq-avg"><?php echo esc_html($v['avg']); ?></span>
               </span>
             </div>
           </button>
@@ -154,9 +154,9 @@ function vq_video_list_shortcode($atts){
     $url = get_post_meta($video_id, '_vq_video_file', true);
 
     // امتیاز فعلی برای نمایش اولیه
-    $sum = get_post_meta($video_id, 'vq_video_rating_sum', true);
+    $avg = get_post_meta($video_id, 'vq_video_rating_avg', true);
     $cnt = get_post_meta($video_id, 'vq_video_rating_count', true);
-    if ($sum === '' ) $sum = 0;
+    if ($avg === '' ) $avg = 0;
     if ($cnt === '' ) $cnt = 0;
 
     echo '<div class="vq-step-card" data-step-index="'.esc_attr($index).'">';
@@ -216,8 +216,8 @@ function vq_video_list_shortcode($atts){
             }
           echo '</div>';
 
-          // ✅ نمایش مجموع و تعداد رأی (JS آن را زنده آپدیت می‌کند)
-          echo '<div class="vq-rating-summary">مجموع: <b class="vq-sum">'.esc_html($sum).'</b> · <span class="vq-count">'.intval($cnt).'</span> رای</div>';
+          // ✅ نمایش میانگین و تعداد رأی (JS آن را زنده آپدیت می‌کند)
+          echo '<div class="vq-rating-summary">میانگین: <b class="vq-avg">'.esc_html($avg).'</b> · <span class="vq-count">'.intval($cnt).'</span> رای</div>';
         echo '</div>'; // .vq-video-rate-wrap
 
         echo '<button class="vq-next-video" data-index="'.esc_attr($index).'">رفتن به ویدیو بعدی</button>';
@@ -240,7 +240,7 @@ function vq_video_list_shortcode($atts){
 add_shortcode('vq_video_list','vq_video_list_shortcode');
 
 /**
- * بهترین ویدیوها بر اساس مجموع امتیاز
+ * بهترین ویدیوها بر اساس امتیاز میانگین
  * [vq_top_videos count="10"]
  */
 function vq_top_videos_shortcode($atts){
@@ -250,7 +250,7 @@ function vq_top_videos_shortcode($atts){
     'post_type'      => ['vq_video','videoquest'],
     'post_status'    => 'publish',
     'posts_per_page' => intval($atts['count']),
-    'meta_key'       => 'vq_video_rating_sum',
+    'meta_key'       => 'vq_video_rating_avg',
     'orderby'        => 'meta_value_num',
     'order'          => 'DESC',
   ]);
@@ -260,11 +260,11 @@ function vq_top_videos_shortcode($atts){
   if( $q->have_posts() ){
     while( $q->have_posts() ){ $q->the_post();
       $vid = get_the_ID();
-      $sum = get_post_meta($vid,'vq_video_rating_sum',true);
+      $avg = get_post_meta($vid,'vq_video_rating_avg',true);
       $cnt = get_post_meta($vid,'vq_video_rating_count',true);
-      if ($sum === '' ) $sum = 0;
+      if ($avg === '' ) $avg = 0;
       if ($cnt === '' ) $cnt = 0;
-      echo '<div class="vq-top-item"><span class="vq-top-title">'.esc_html(get_the_title()).'</span> <span class="vq-top-meta">— مجموع: <span class="vq-sum">'.esc_html($sum).'</span> امتیاز · '.intval($cnt).' رای</span></div>';
+      echo '<div class="vq-top-item"><span class="vq-top-title">'.esc_html(get_the_title()).'</span> <span class="vq-top-meta">— میانگین: <span class="vq-avg">'.esc_html($avg).'</span> · '.intval($cnt).' رای</span></div>';
     }
     wp_reset_postdata();
   } else {


### PR DESCRIPTION
## Summary
- persist quiz results per user and allow 70% pass threshold
- fix rating summary to use average and show correct values
- polish playlist UI with feedback colors and hover styles

## Testing
- `php -l includes/ajax.php`
- `php -l shortcodes.php`
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af264824a883289c22d927cd072e90